### PR TITLE
Add Quran module scaffolding

### DIFF
--- a/Salatuk Pro/ContentView.swift
+++ b/Salatuk Pro/ContentView.swift
@@ -1778,26 +1778,26 @@ Spacer()
         }
     }
     HStack(spacing: 14) {
-        
-        NavigationLink(destination: AlzakeerMenuView()) {
+
+        NavigationLink(destination: QuranHomeView()) {
             HStack(spacing: 12) {
-                Image("alzakeerIcon")
+                Image(systemName: "book")
                     .resizable()
                     .scaledToFit()
                     .frame(width: 50, height: 50)
                     .background(Color.white.opacity(0.2))
-    .clipShape(Circle())
-    .overlay(
-        Circle()
-            .stroke(Color.gray, lineWidth: 2)
-    )
-    .padding(.leading, 8)
-                
-                Text("جميع الأقسام")
+                    .clipShape(Circle())
+                    .overlay(
+                        Circle()
+                            .stroke(Color.gray, lineWidth: 2)
+                    )
+                    .padding(.leading, 8)
+
+                Text(LocalizedStringKey("quran.title"))
                     .font(.system(size: 15))
                     .foregroundColor(.white)
                     .padding(.leading, 8)
-                
+
                 Spacer()
             }
             .padding(0)
@@ -1808,7 +1808,37 @@ Spacer()
                     .strokeBorder(Color.slateGray, lineWidth: 2)
             )
         }
-        
+
+        NavigationLink(destination: AlzakeerMenuView()) {
+            HStack(spacing: 12) {
+                Image("alzakeerIcon")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 50, height: 50)
+                    .background(Color.white.opacity(0.2))
+                    .clipShape(Circle())
+                    .overlay(
+                        Circle()
+                            .stroke(Color.gray, lineWidth: 2)
+                    )
+                    .padding(.leading, 8)
+
+                Text("جميع الأقسام")
+                    .font(.system(size: 15))
+                    .foregroundColor(.white)
+                    .padding(.leading, 8)
+
+                Spacer()
+            }
+            .padding(0)
+            .frame(width: 180, height: 60)
+            .background(Color.clear)
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .strokeBorder(Color.slateGray, lineWidth: 2)
+            )
+        }
+
 
     }
 

--- a/Salatuk Pro/QuranModule/Models/Ayah.swift
+++ b/Salatuk Pro/QuranModule/Models/Ayah.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Ayah: Identifiable, Codable {
+    let id: Int
+    let text: String
+    let numberInSurah: Int
+}

--- a/Salatuk Pro/QuranModule/Models/Surah.swift
+++ b/Salatuk Pro/QuranModule/Models/Surah.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct Surah: Identifiable, Codable {
+    let id: Int
+    let name: String
+    let englishName: String
+    let englishNameTranslation: String?
+    let numberOfAyahs: Int
+}

--- a/Salatuk Pro/QuranModule/Models/Tafsir.swift
+++ b/Salatuk Pro/QuranModule/Models/Tafsir.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Tafsir: Identifiable, Codable {
+    let id: Int
+    let text: String
+    let source: String
+}

--- a/Salatuk Pro/QuranModule/QuranTheme.swift
+++ b/Salatuk Pro/QuranModule/QuranTheme.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+/// Shared gradient background used across Quran views
+let quranBackgroundGradient = LinearGradient(
+    gradient: Gradient(colors: [
+        Color(red: 0.05, green: 0.05, blue: 0.15),
+        Color(red: 0.2, green: 0.1, blue: 0.3),
+        Color(red: 0.1, green: 0.15, blue: 0.3),
+        Color(red: 0.05, green: 0.15, blue: 0.1),
+        Color(red: 0.15, green: 0.05, blue: 0.25)
+    ]),
+    startPoint: .topLeading,
+    endPoint: .bottomTrailing
+)

--- a/Salatuk Pro/QuranModule/Services/BookmarkManager.swift
+++ b/Salatuk Pro/QuranModule/Services/BookmarkManager.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+class BookmarkManager: ObservableObject {
+    static let shared = BookmarkManager()
+    @Published private(set) var bookmarks: Set<String> = [] // format: "surah:ayah"
+    private let defaultsKey = "quranBookmarks"
+
+    private init() {
+        if let saved = UserDefaults.standard.array(forKey: defaultsKey) as? [String] {
+            bookmarks = Set(saved)
+        }
+    }
+
+    func toggleBookmark(surah: Int, ayah: Int) {
+        let key = "\(surah):\(ayah)"
+        if bookmarks.contains(key) {
+            bookmarks.remove(key)
+        } else {
+            bookmarks.insert(key)
+        }
+        UserDefaults.standard.set(Array(bookmarks), forKey: defaultsKey)
+        // TODO: Sync with iCloud
+    }
+
+    func isBookmarked(surah: Int, ayah: Int) -> Bool {
+        bookmarks.contains("\(surah):\(ayah)")
+    }
+}

--- a/Salatuk Pro/QuranModule/Services/QuranAPIProtocol.swift
+++ b/Salatuk Pro/QuranModule/Services/QuranAPIProtocol.swift
@@ -1,0 +1,8 @@
+import Foundation
+import Combine
+
+protocol QuranAPIProtocol {
+    func fetchSurahs() -> AnyPublisher<[Surah], Error>
+    func fetchAyat(forSurah number: Int) -> AnyPublisher<[Ayah], Error>
+    func fetchTafsir(surah: Int, ayah: Int) -> AnyPublisher<Tafsir, Error>
+}

--- a/Salatuk Pro/QuranModule/Services/QuranAPIService.swift
+++ b/Salatuk Pro/QuranModule/Services/QuranAPIService.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Combine
+
+class QuranAPIService: QuranAPIProtocol {
+    static let shared = QuranAPIService()
+    private let session: URLSession
+    private let baseURL = URL(string: "https://api.alquran.cloud/v1")!
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func fetchSurahs() -> AnyPublisher<[Surah], Error> {
+        let url = baseURL.appendingPathComponent("surah")
+        return session.dataTaskPublisher(for: url)
+            .map(\.$data)
+            .decode(type: SurahListResponse.self, decoder: JSONDecoder())
+            .map { $0.data.map { Surah(id: $0.number,
+                                       name: $0.name,
+                                       englishName: $0.englishName,
+                                       englishNameTranslation: $0.englishNameTranslation,
+                                       numberOfAyahs: $0.numberOfAyahs) } }
+            .eraseToAnyPublisher()
+    }
+
+    func fetchAyat(forSurah number: Int) -> AnyPublisher<[Ayah], Error> {
+        let url = baseURL.appendingPathComponent("surah/\(number)/ar.uthmani")
+        return session.dataTaskPublisher(for: url)
+            .map(\.$data)
+            .decode(type: AyahListResponse.self, decoder: JSONDecoder())
+            .map { $0.data.ayahs.map { Ayah(id: $0.number,
+                                            text: $0.text,
+                                            numberInSurah: $0.numberInSurah) } }
+            .eraseToAnyPublisher()
+    }
+
+    func fetchTafsir(surah: Int, ayah: Int) -> AnyPublisher<Tafsir, Error> {
+        // Placeholder endpoint; adjust with real tafsir API
+        let url = URL(string: "https://api.quran.com/api/v4/tafsirs/by_ayah/\(ayah)?tafsir_id=169")!
+        return session.dataTaskPublisher(for: url)
+            .map(\.$data)
+            .decode(type: TafsirResponse.self, decoder: JSONDecoder())
+            .tryMap { resp in
+                guard let first = resp.tafsirs.first else {
+                    throw URLError(.badServerResponse)
+                }
+                return Tafsir(id: first.id, text: first.text, source: first.resourceName)
+            }
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Response Models
+private struct SurahListResponse: Codable {
+    struct SurahData: Codable {
+        let number: Int
+        let name: String
+        let englishName: String
+        let englishNameTranslation: String?
+        let numberOfAyahs: Int
+    }
+    let data: [SurahData]
+}
+
+private struct AyahListResponse: Codable {
+    struct AyahData: Codable {
+        let number: Int
+        let text: String
+        let numberInSurah: Int
+    }
+    struct AyahContainer: Codable {
+        let ayahs: [AyahData]
+    }
+    let data: AyahContainer
+}
+
+private struct TafsirResponse: Codable {
+    struct TafsirData: Codable {
+        let id: Int
+        let text: String
+        let resourceName: String
+    }
+    let tafsirs: [TafsirData]
+}

--- a/Salatuk Pro/QuranModule/ViewModels/SurahDetailViewModel.swift
+++ b/Salatuk Pro/QuranModule/ViewModels/SurahDetailViewModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Combine
+
+class SurahDetailViewModel: ObservableObject {
+    @Published var ayat: [Ayah] = []
+    @Published var isLoading = false
+    private var cancellables = Set<AnyCancellable>()
+    private let service: QuranAPIProtocol
+    let surah: Surah
+
+    init(surah: Surah, service: QuranAPIProtocol = QuranAPIService.shared) {
+        self.surah = surah
+        self.service = service
+    }
+
+    func loadAyat() {
+        isLoading = true
+        service.fetchAyat(forSurah: surah.id)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                self?.isLoading = false
+                if case let .failure(error) = completion {
+                    print("Failed to fetch ayat", error)
+                }
+            }, receiveValue: { [weak self] ayat in
+                self?.ayat = ayat
+            })
+            .store(in: &cancellables)
+    }
+}

--- a/Salatuk Pro/QuranModule/ViewModels/SurahListViewModel.swift
+++ b/Salatuk Pro/QuranModule/ViewModels/SurahListViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Combine
+
+class SurahListViewModel: ObservableObject {
+    @Published var surahs: [Surah] = []
+    @Published var isLoading = false
+    private var cancellables = Set<AnyCancellable>()
+    private let service: QuranAPIProtocol
+
+    init(service: QuranAPIProtocol = QuranAPIService.shared) {
+        self.service = service
+    }
+
+    func loadSurahs() {
+        isLoading = true
+        service.fetchSurahs()
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                self?.isLoading = false
+                if case let .failure(error) = completion {
+                    print("Failed to fetch surahs", error)
+                }
+            }, receiveValue: { [weak self] surahs in
+                self?.surahs = surahs
+            })
+            .store(in: &cancellables)
+    }
+}

--- a/Salatuk Pro/QuranModule/ViewModels/TafsirViewModel.swift
+++ b/Salatuk Pro/QuranModule/ViewModels/TafsirViewModel.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Combine
+
+class TafsirViewModel: ObservableObject {
+    @Published var tafsir: Tafsir?
+    @Published var isLoading = false
+    private var cancellables = Set<AnyCancellable>()
+    private let service: QuranAPIProtocol
+    let surah: Int
+    let ayah: Int
+
+    init(surah: Int, ayah: Int, service: QuranAPIProtocol = QuranAPIService.shared) {
+        self.surah = surah
+        self.ayah = ayah
+        self.service = service
+    }
+
+    func loadTafsir() {
+        isLoading = true
+        service.fetchTafsir(surah: surah, ayah: ayah)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                self?.isLoading = false
+                if case let .failure(error) = completion {
+                    print("Failed to fetch tafsir", error)
+                }
+            }, receiveValue: { [weak self] tafsir in
+                self?.tafsir = tafsir
+            })
+            .store(in: &cancellables)
+    }
+}

--- a/Salatuk Pro/QuranModule/Views/QuranHomeView.swift
+++ b/Salatuk Pro/QuranModule/Views/QuranHomeView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct QuranHomeView: View {
+    var body: some View {
+        SurahListView()
+    }
+}
+
+struct QuranHomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        QuranHomeView()
+    }
+}

--- a/Salatuk Pro/QuranModule/Views/SurahDetailView.swift
+++ b/Salatuk Pro/QuranModule/Views/SurahDetailView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// Detail view showing ayat of a surah using app styling
+
+struct SurahDetailView: View {
+    @StateObject private var viewModel: SurahDetailViewModel
+
+    init(surah: Surah) {
+        _viewModel = StateObject(wrappedValue: SurahDetailViewModel(surah: surah))
+    }
+
+    var body: some View {
+        ZStack {
+            quranBackgroundGradient.ignoresSafeArea()
+
+            List(viewModel.ayat) { ayah in
+                NavigationLink(destination: TafsirView(surah: viewModel.surah.id, ayah: ayah.numberInSurah)) {
+                    VStack(alignment: .trailing) {
+                        Text(ayah.text)
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                }
+                .listRowBackground(Color.clear)
+            }
+            .listStyle(.plain)
+        }
+        .navigationTitle(viewModel.surah.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { viewModel.loadAyat() }
+    }
+}
+
+struct SurahDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            SurahDetailView(surah: Surah(id: 1, name: "الفاتحة", englishName: "Al-Fatihah", englishNameTranslation: nil, numberOfAyahs: 7))
+        }
+    }
+}

--- a/Salatuk Pro/QuranModule/Views/SurahListView.swift
+++ b/Salatuk Pro/QuranModule/Views/SurahListView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// List of all surahs with styling similar to the rest of the app
+
+struct SurahListView: View {
+    @StateObject private var viewModel = SurahListViewModel()
+
+    var body: some View {
+        ZStack {
+            quranBackgroundGradient.ignoresSafeArea()
+
+            List(viewModel.surahs) { surah in
+                NavigationLink(destination: SurahDetailView(surah: surah)) {
+                    HStack {
+                        Text("\(surah.id).")
+                            .foregroundColor(.white)
+                        Text(surah.name)
+                            .foregroundColor(.white)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+                .listRowBackground(Color.clear)
+            }
+            .listStyle(.plain)
+        }
+        .navigationTitle(LocalizedStringKey("quran.title"))
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { viewModel.loadSurahs() }
+    }
+}
+
+struct SurahListView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView { SurahListView() }
+    }
+}

--- a/Salatuk Pro/QuranModule/Views/TafsirView.swift
+++ b/Salatuk Pro/QuranModule/Views/TafsirView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// Shows tafsir for a single ayah with app styling
+
+struct TafsirView: View {
+    @StateObject private var viewModel: TafsirViewModel
+
+    init(surah: Int, ayah: Int) {
+        _viewModel = StateObject(wrappedValue: TafsirViewModel(surah: surah, ayah: ayah))
+    }
+
+    var body: some View {
+        ZStack {
+            quranBackgroundGradient.ignoresSafeArea()
+
+            ScrollView {
+                if let tafsir = viewModel.tafsir {
+                    Text(tafsir.text)
+                        .foregroundColor(.white)
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                } else if viewModel.isLoading {
+                    ProgressView()
+                } else {
+                    Text(LocalizedStringKey("no.tafsir"))
+                        .foregroundColor(.white)
+                }
+            }
+        }
+        .navigationTitle(LocalizedStringKey("tafsir.title"))
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { viewModel.loadTafsir() }
+    }
+}
+
+struct TafsirView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView { TafsirView(surah: 1, ayah: 1) }
+    }
+}

--- a/Salatuk Pro/Resources/ar.lproj/QuranModule.strings
+++ b/Salatuk Pro/Resources/ar.lproj/QuranModule.strings
@@ -1,0 +1,3 @@
+"quran.title" = "القرآن";
+"tafsir.title" = "تفسير";
+"no.tafsir" = "لا يوجد تفسير";

--- a/Salatuk Pro/Resources/en.lproj/QuranModule.strings
+++ b/Salatuk Pro/Resources/en.lproj/QuranModule.strings
@@ -1,0 +1,3 @@
+"quran.title" = "Qur'an";
+"tafsir.title" = "Tafsir";
+"no.tafsir" = "No Tafsir";

--- a/Salatuk ProTests/QuranAPIServiceTests.swift
+++ b/Salatuk ProTests/QuranAPIServiceTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Salatuk_Pro
+
+final class QuranAPIServiceTests: XCTestCase {
+    func testFetchSurahs() {
+        // TODO: Implement network mock and verify parsing
+    }
+
+    func testFetchAyat() {
+        // TODO: Implement network mock and verify parsing
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold QuranModule with models, view models, views and services
- add Quran API service fetching surahs and ayat
- integrate Quran module entry in ContentView
- add localization strings for Quran module
- add unit test stubs for Quran API service
- style Quran views to match rest of app

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6868064bee3c83269e28a21fbe35bf5b