### PR TITLE
Add Quran module scaffolding

### DIFF
--- a/Salatuk Pro.xcodeproj/project.pbxproj
+++ b/Salatuk Pro.xcodeproj/project.pbxproj
@@ -57,7 +57,23 @@
 		307461822E035EB000021EDB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 300784052DC03BE500A972C0 /* UIKit.framework */; };
 		307461842E035EB300021EDB /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 300784102DC03C8800A972C0 /* UserNotifications.framework */; };
 		307461882E036D1300021EDB /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3074618A2E036D1300021EDB /* Localizable.strings */; };
-		307F03612E021288003962EB /* DhikrDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 307F03602E021287003962EB /* DhikrDetailView.swift */; };
+                307F03612E021288003962EB /* DhikrDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 307F03602E021287003962EB /* DhikrDetailView.swift */; };
+                7650437AAC4079BE7774BE0E /* QuranTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B99B8D779D05D2A631725A /* QuranTheme.swift */; };
+                ED74802F386188CA0A14EEBD /* Ayah.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A228D1C977AA8CB2E11DF5 /* Ayah.swift */; };
+                559D0F01B3D7E30FB9ED9155 /* Surah.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A648F8204425F17F02DBF52 /* Surah.swift */; };
+                408D273309C8F6FB0E0A4189 /* Tafsir.swift in Sources */ = {isa = PBXBuildFile; fileRef = B982EBE133A9F90BD9FC7F3E /* Tafsir.swift */; };
+                DA77692D918AB60EDA4EC966 /* BookmarkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D05550595EBF30C2EF4F2B /* BookmarkManager.swift */; };
+                1727BAD968A98C93B8E14178 /* QuranAPIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD861FFBA00EFBD34ABA468 /* QuranAPIProtocol.swift */; };
+                99FEF0B4F185A14086243383 /* QuranAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1919B1C1861A8AD8CB1F4C13 /* QuranAPIService.swift */; };
+                61720EC33958E15766F2183E /* SurahDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5980B87A5403E703842C12 /* SurahDetailViewModel.swift */; };
+                E4E6E5447A3DE011DE8D6BD5 /* SurahListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3940FFC3AA0E67D407065A3D /* SurahListViewModel.swift */; };
+                80AD7BC18841CE515587046D /* TafsirViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E41CB61FD7242DC5C2ED2B /* TafsirViewModel.swift */; };
+                A2F3033091CCF73FE2F80291 /* QuranHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545BF10794E50E639BD0DCC9 /* QuranHomeView.swift */; };
+                62C09E166DE3CAA868D1804E /* SurahDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B8C0CFE295FF3B24B33479E /* SurahDetailView.swift */; };
+                770E3BBFACD736052FBF8722 /* SurahListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80B1A2A240D8B80A85B17CD /* SurahListView.swift */; };
+                550D80FB84A1ACA24B511788 /* TafsirView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF044D2E6071B1019BD81703 /* TafsirView.swift */; };
+                2E1FA5DE3FFCF3484E185D16 /* QuranAPIServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB671DD9DA00032A3E73426 /* QuranAPIServiceTests.swift */; };
+                5B45614E6D38DC582A070B2B /* QuranModule.strings in Resources */ = {isa = PBXBuildFile; fileRef = C0A3A8ED95CF7E5D15E3A622 /* QuranModule.strings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -130,7 +146,24 @@
 		308804052DCAE59A00315319 /* CoreHaptics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreHaptics.framework; path = System/Library/Frameworks/CoreHaptics.framework; sourceTree = SDKROOT; };
 		308804072DCAE61F00315319 /* ZakatCalculatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZakatCalculatorView.swift; sourceTree = "<group>"; };
 		308804092DCAE63400315319 /* GpsBoslaView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GpsBoslaView.swift; sourceTree = "<group>"; };
-		3089B7A52DC40DCC00B61A86 /* CardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
+                3089B7A52DC40DCC00B61A86 /* CardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
+                24B99B8D779D05D2A631725A /* QuranTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/QuranTheme.swift; sourceTree = "<group>"; };
+                B9A228D1C977AA8CB2E11DF5 /* Ayah.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/Models/Ayah.swift; sourceTree = "<group>"; };
+                4A648F8204425F17F02DBF52 /* Surah.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/Models/Surah.swift; sourceTree = "<group>"; };
+                B982EBE133A9F90BD9FC7F3E /* Tafsir.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/Models/Tafsir.swift; sourceTree = "<group>"; };
+                67D05550595EBF30C2EF4F2B /* BookmarkManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/Services/BookmarkManager.swift; sourceTree = "<group>"; };
+                1BD861FFBA00EFBD34ABA468 /* QuranAPIProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/Services/QuranAPIProtocol.swift; sourceTree = "<group>"; };
+                1919B1C1861A8AD8CB1F4C13 /* QuranAPIService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/Services/QuranAPIService.swift; sourceTree = "<group>"; };
+                DD5980B87A5403E703842C12 /* SurahDetailViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/ViewModels/SurahDetailViewModel.swift; sourceTree = "<group>"; };
+                3940FFC3AA0E67D407065A3D /* SurahListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/ViewModels/SurahListViewModel.swift; sourceTree = "<group>"; };
+                F8E41CB61FD7242DC5C2ED2B /* TafsirViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/ViewModels/TafsirViewModel.swift; sourceTree = "<group>"; };
+                545BF10794E50E639BD0DCC9 /* QuranHomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/Views/QuranHomeView.swift; sourceTree = "<group>"; };
+                1B8C0CFE295FF3B24B33479E /* SurahDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/Views/SurahDetailView.swift; sourceTree = "<group>"; };
+                C80B1A2A240D8B80A85B17CD /* SurahListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/Views/SurahListView.swift; sourceTree = "<group>"; };
+                DF044D2E6071B1019BD81703 /* TafsirView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuranModule/Views/TafsirView.swift; sourceTree = "<group>"; };
+                2EB671DD9DA00032A3E73426 /* QuranAPIServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Salatuk\ ProTests/QuranAPIServiceTests.swift; sourceTree = "<group>"; };
+                5E1700128AB1861A36672F12 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/QuranModule.strings; sourceTree = "<group>"; };
+                B5BA5FFE8D4A6DBC8B8FD6EE /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/QuranModule.strings; sourceTree = "<group>"; };
 		30B38E352DDF95B5006276E1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		30B38E3A2DDFAAAF006276E1 /* azan.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = azan.m4a; sourceTree = "<group>"; };
 		30B38E3B2DDFAAB0006276E1 /* click.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = click.mp3; sourceTree = "<group>"; };
@@ -203,8 +236,9 @@
 				308804072DCAE61F00315319 /* ZakatCalculatorView.swift */,
 				30867E6B2DDF11F800DC99AF /* DhikrType.swift */,
 				300783CC2DC03AF000A972C0 /* ContentView.swift */,
-				3089B7A52DC40DCC00B61A86 /* CardView.swift */,
-				300783CD2DC03AF000A972C0 /* My App.swift */,
+                               3089B7A52DC40DCC00B61A86 /* CardView.swift */,
+                                71EC04E07D4329DB231221A1 /* QuranModule */,
+                               300783CD2DC03AF000A972C0 /* My App.swift */,
 				300783D02DC03AF000A972C0 /* Adhan.h */,
 				300783B82DC03AEF00A972C0 /* AdhanObjc.swift */,
 				300783B92DC03AEF00A972C0 /* PrayerTimes.swift */,
@@ -239,11 +273,12 @@
 				3074618C2E036D9F00021EDB /* en.lproj */,
 				30963D4E2DFA3DD3008A4534 /* ar.lproj */,
 				30B38E3A2DDFAAAF006276E1 /* azan.m4a */,
-				30B38E3B2DDFAAB0006276E1 /* click.mp3 */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
+                               30B38E3B2DDFAAB0006276E1 /* click.mp3 */,
+                                C0A3A8ED95CF7E5D15E3A622 /* QuranModule.strings */,
+                        );
+                        path = Resources;
+                        sourceTree = "<group>";
+                };
 		300783B42DC03AEF00A972C0 /* Astronomy */ = {
 			isa = PBXGroup;
 			children = (
@@ -304,14 +339,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		3018891A2DF4D0ED004540A2 /* Salatuk ProTests */ = {
-			isa = PBXGroup;
-			children = (
-				3018891B2DF4D0ED004540A2 /* Salatuk_ProTests.swift */,
-			);
-			path = "Salatuk ProTests";
-			sourceTree = "<group>";
-		};
+                3018891A2DF4D0ED004540A2 /* Salatuk ProTests */ = {
+                        isa = PBXGroup;
+                        children = (
+                                3018891B2DF4D0ED004540A2 /* Salatuk_ProTests.swift */,
+                                2EB671DD9DA00032A3E73426 /* QuranAPIServiceTests.swift */,
+                        );
+                        path = "Salatuk ProTests";
+                        sourceTree = "<group>";
+                };
 		3018891D2DF4D0FD004540A2 /* Salatuk ProUITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -321,13 +357,14 @@
 			path = "Salatuk ProUITests";
 			sourceTree = "<group>";
 		};
-		3074618C2E036D9F00021EDB /* en.lproj */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = en.lproj;
-			sourceTree = "<group>";
-		};
+                3074618C2E036D9F00021EDB /* en.lproj */ = {
+                        isa = PBXGroup;
+                        children = (
+                                B5BA5FFE8D4A6DBC8B8FD6EE /* en */,
+                        );
+                        path = en.lproj;
+                        sourceTree = "<group>";
+                };
 		307461902E036E5600021EDB /* Base.lproj */ = {
 			isa = PBXGroup;
 			children = (
@@ -344,13 +381,67 @@
 			path = xd;
 			sourceTree = "<group>";
 		};
-		30963D4E2DFA3DD3008A4534 /* ar.lproj */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = ar.lproj;
-			sourceTree = "<group>";
-		};
+                30963D4E2DFA3DD3008A4534 /* ar.lproj */ = {
+                        isa = PBXGroup;
+                        children = (
+                                5E1700128AB1861A36672F12 /* ar */,
+                        );
+                        path = ar.lproj;
+                        sourceTree = "<group>";
+                };
+                71EC04E07D4329DB231221A1 /* QuranModule */ = {
+                        isa = PBXGroup;
+                        children = (
+                                29B66DD359A4DB8CCCA2C36C /* Models */,
+                                283546F45C6108B84AB3A8C9 /* Services */,
+                                CF2A5D4D283C78C479F8B976 /* ViewModels */,
+                                64F06D53838DBF7EF7AA224C /* Views */,
+                                24B99B8D779D05D2A631725A /* QuranTheme.swift */,
+                        );
+                        path = QuranModule;
+                        sourceTree = "<group>";
+                };
+                29B66DD359A4DB8CCCA2C36C /* Models */ = {
+                        isa = PBXGroup;
+                        children = (
+                                B9A228D1C977AA8CB2E11DF5 /* Ayah.swift */,
+                                4A648F8204425F17F02DBF52 /* Surah.swift */,
+                                B982EBE133A9F90BD9FC7F3E /* Tafsir.swift */,
+                        );
+                        path = Models;
+                        sourceTree = "<group>";
+                };
+                283546F45C6108B84AB3A8C9 /* Services */ = {
+                        isa = PBXGroup;
+                        children = (
+                                67D05550595EBF30C2EF4F2B /* BookmarkManager.swift */,
+                                1BD861FFBA00EFBD34ABA468 /* QuranAPIProtocol.swift */,
+                                1919B1C1861A8AD8CB1F4C13 /* QuranAPIService.swift */,
+                        );
+                        path = Services;
+                        sourceTree = "<group>";
+                };
+                CF2A5D4D283C78C479F8B976 /* ViewModels */ = {
+                        isa = PBXGroup;
+                        children = (
+                                DD5980B87A5403E703842C12 /* SurahDetailViewModel.swift */,
+                                3940FFC3AA0E67D407065A3D /* SurahListViewModel.swift */,
+                                F8E41CB61FD7242DC5C2ED2B /* TafsirViewModel.swift */,
+                        );
+                        path = ViewModels;
+                        sourceTree = "<group>";
+                };
+                64F06D53838DBF7EF7AA224C /* Views */ = {
+                        isa = PBXGroup;
+                        children = (
+                                545BF10794E50E639BD0DCC9 /* QuranHomeView.swift */,
+                                1B8C0CFE295FF3B24B33479E /* SurahDetailView.swift */,
+                                C80B1A2A240D8B80A85B17CD /* SurahListView.swift */,
+                                DF044D2E6071B1019BD81703 /* TafsirView.swift */,
+                        );
+                        path = Views;
+                        sourceTree = "<group>";
+                };
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -488,8 +579,9 @@
 			files = (
 				301888D22DF4C87F004540A2 /* Preview Assets.xcassets in Resources */,
 				301888C12DF4C83E004540A2 /* entitlements.plist in Resources */,
-				301888CE2DF4C869004540A2 /* click.mp3 in Resources */,
-				307461882E036D1300021EDB /* Localizable.strings in Resources */,
+                               301888CE2DF4C869004540A2 /* click.mp3 in Resources */,
+                                5B45614E6D38DC582A070B2B /* QuranModule.strings in Resources */,
+                                307461882E036D1300021EDB /* Localizable.strings in Resources */,
 				301888D12DF4C874004540A2 /* Assets.xcassets in Resources */,
 				301888CD2DF4C867004540A2 /* azan.m4a in Resources */,
 				301888AD2DF4C7ED004540A2 /* GoogleService-Info.plist in Resources */,
@@ -548,18 +640,33 @@
 				301888B12DF4C7FE004540A2 /* adkarsl2.swift in Sources */,
 				301888C92DF4C859004540A2 /* Prayer.swift in Sources */,
 				301888BD2DF4C82F004540A2 /* SunnahTimes.swift in Sources */,
-				301888C72DF4C853004540A2 /* PrayerAdjustment.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3018888D2DF4C736004540A2 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				301889242DF4DA92004540A2 /* Salatuk_ProTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                                301888C72DF4C853004540A2 /* PrayerAdjustment.swift in Sources */,
+                                7650437AAC4079BE7774BE0E /* QuranTheme.swift in Sources */,
+                                ED74802F386188CA0A14EEBD /* Ayah.swift in Sources */,
+                                559D0F01B3D7E30FB9ED9155 /* Surah.swift in Sources */,
+                                408D273309C8F6FB0E0A4189 /* Tafsir.swift in Sources */,
+                                DA77692D918AB60EDA4EC966 /* BookmarkManager.swift in Sources */,
+                                1727BAD968A98C93B8E14178 /* QuranAPIProtocol.swift in Sources */,
+                                99FEF0B4F185A14086243383 /* QuranAPIService.swift in Sources */,
+                                61720EC33958E15766F2183E /* SurahDetailViewModel.swift in Sources */,
+                                E4E6E5447A3DE011DE8D6BD5 /* SurahListViewModel.swift in Sources */,
+                                80AD7BC18841CE515587046D /* TafsirViewModel.swift in Sources */,
+                                A2F3033091CCF73FE2F80291 /* QuranHomeView.swift in Sources */,
+                                62C09E166DE3CAA868D1804E /* SurahDetailView.swift in Sources */,
+                                770E3BBFACD736052FBF8722 /* SurahListView.swift in Sources */,
+                                550D80FB84A1ACA24B511788 /* TafsirView.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+                3018888D2DF4C736004540A2 /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                301889242DF4DA92004540A2 /* Salatuk_ProTests.swift in Sources */,
+                                2E1FA5DE3FFCF3484E185D16 /* QuranAPIServiceTests.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 		301888972DF4C737004540A2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -689,15 +796,24 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		3074618A2E036D1300021EDB /* Localizable.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				307461892E036D1300021EDB /* ar */,
-				3074618B2E036D2000021EDB /* en */,
-			);
-			name = Localizable.strings;
-			sourceTree = "<group>";
-		};
+                3074618A2E036D1300021EDB /* Localizable.strings */ = {
+                        isa = PBXVariantGroup;
+                        children = (
+                                307461892E036D1300021EDB /* ar */,
+                                3074618B2E036D2000021EDB /* en */,
+                        );
+                        name = Localizable.strings;
+                        sourceTree = "<group>";
+                };
+                C0A3A8ED95CF7E5D15E3A622 /* QuranModule.strings */ = {
+                        isa = PBXVariantGroup;
+                        children = (
+                                5E1700128AB1861A36672F12 /* ar */,
+                                B5BA5FFE8D4A6DBC8B8FD6EE /* en */,
+                        );
+                        name = QuranModule.strings;
+                        sourceTree = "<group>";
+                };
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */

--- a/Salatuk Pro/ContentView.swift
+++ b/Salatuk Pro/ContentView.swift
@@ -1778,26 +1778,26 @@ Spacer()
         }
     }
     HStack(spacing: 14) {
-        
-        NavigationLink(destination: AlzakeerMenuView()) {
+
+        NavigationLink(destination: QuranHomeView()) {
             HStack(spacing: 12) {
-                Image("alzakeerIcon")
+                Image(systemName: "book")
                     .resizable()
                     .scaledToFit()
                     .frame(width: 50, height: 50)
                     .background(Color.white.opacity(0.2))
-    .clipShape(Circle())
-    .overlay(
-        Circle()
-            .stroke(Color.gray, lineWidth: 2)
-    )
-    .padding(.leading, 8)
-                
-                Text("جميع الأقسام")
+                    .clipShape(Circle())
+                    .overlay(
+                        Circle()
+                            .stroke(Color.gray, lineWidth: 2)
+                    )
+                    .padding(.leading, 8)
+
+                Text(LocalizedStringKey("quran.title"))
                     .font(.system(size: 15))
                     .foregroundColor(.white)
                     .padding(.leading, 8)
-                
+
                 Spacer()
             }
             .padding(0)
@@ -1808,7 +1808,37 @@ Spacer()
                     .strokeBorder(Color.slateGray, lineWidth: 2)
             )
         }
-        
+
+        NavigationLink(destination: AlzakeerMenuView()) {
+            HStack(spacing: 12) {
+                Image("alzakeerIcon")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 50, height: 50)
+                    .background(Color.white.opacity(0.2))
+                    .clipShape(Circle())
+                    .overlay(
+                        Circle()
+                            .stroke(Color.gray, lineWidth: 2)
+                    )
+                    .padding(.leading, 8)
+
+                Text("جميع الأقسام")
+                    .font(.system(size: 15))
+                    .foregroundColor(.white)
+                    .padding(.leading, 8)
+
+                Spacer()
+            }
+            .padding(0)
+            .frame(width: 180, height: 60)
+            .background(Color.clear)
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .strokeBorder(Color.slateGray, lineWidth: 2)
+            )
+        }
+
 
     }
 

--- a/Salatuk Pro/QuranModule/Models/Ayah.swift
+++ b/Salatuk Pro/QuranModule/Models/Ayah.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Ayah: Identifiable, Codable {
+    let id: Int
+    let text: String
+    let numberInSurah: Int
+}

--- a/Salatuk Pro/QuranModule/Models/Surah.swift
+++ b/Salatuk Pro/QuranModule/Models/Surah.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct Surah: Identifiable, Codable {
+    let id: Int
+    let name: String
+    let englishName: String
+    let englishNameTranslation: String?
+    let numberOfAyahs: Int
+}

--- a/Salatuk Pro/QuranModule/Models/Tafsir.swift
+++ b/Salatuk Pro/QuranModule/Models/Tafsir.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Tafsir: Identifiable, Codable {
+    let id: Int
+    let text: String
+    let source: String
+}

--- a/Salatuk Pro/QuranModule/QuranTheme.swift
+++ b/Salatuk Pro/QuranModule/QuranTheme.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+/// Shared gradient background used across Quran views
+let quranBackgroundGradient = LinearGradient(
+    gradient: Gradient(colors: [
+        Color(red: 0.05, green: 0.05, blue: 0.15),
+        Color(red: 0.2, green: 0.1, blue: 0.3),
+        Color(red: 0.1, green: 0.15, blue: 0.3),
+        Color(red: 0.05, green: 0.15, blue: 0.1),
+        Color(red: 0.15, green: 0.05, blue: 0.25)
+    ]),
+    startPoint: .topLeading,
+    endPoint: .bottomTrailing
+)

--- a/Salatuk Pro/QuranModule/Services/BookmarkManager.swift
+++ b/Salatuk Pro/QuranModule/Services/BookmarkManager.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+class BookmarkManager: ObservableObject {
+    static let shared = BookmarkManager()
+    @Published private(set) var bookmarks: Set<String> = [] // format: "surah:ayah"
+    private let defaultsKey = "quranBookmarks"
+
+    private init() {
+        if let saved = UserDefaults.standard.array(forKey: defaultsKey) as? [String] {
+            bookmarks = Set(saved)
+        }
+    }
+
+    func toggleBookmark(surah: Int, ayah: Int) {
+        let key = "\(surah):\(ayah)"
+        if bookmarks.contains(key) {
+            bookmarks.remove(key)
+        } else {
+            bookmarks.insert(key)
+        }
+        UserDefaults.standard.set(Array(bookmarks), forKey: defaultsKey)
+        // TODO: Sync with iCloud
+    }
+
+    func isBookmarked(surah: Int, ayah: Int) -> Bool {
+        bookmarks.contains("\(surah):\(ayah)")
+    }
+}

--- a/Salatuk Pro/QuranModule/Services/QuranAPIProtocol.swift
+++ b/Salatuk Pro/QuranModule/Services/QuranAPIProtocol.swift
@@ -1,0 +1,8 @@
+import Foundation
+import Combine
+
+protocol QuranAPIProtocol {
+    func fetchSurahs() -> AnyPublisher<[Surah], Error>
+    func fetchAyat(forSurah number: Int) -> AnyPublisher<[Ayah], Error>
+    func fetchTafsir(surah: Int, ayah: Int) -> AnyPublisher<Tafsir, Error>
+}

--- a/Salatuk Pro/QuranModule/Services/QuranAPIService.swift
+++ b/Salatuk Pro/QuranModule/Services/QuranAPIService.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Combine
+
+class QuranAPIService: QuranAPIProtocol {
+    static let shared = QuranAPIService()
+    private let session: URLSession
+    private let baseURL = URL(string: "https://api.alquran.cloud/v1")!
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func fetchSurahs() -> AnyPublisher<[Surah], Error> {
+        let url = baseURL.appendingPathComponent("surah")
+        return session.dataTaskPublisher(for: url)
+            .map(\.$data)
+            .decode(type: SurahListResponse.self, decoder: JSONDecoder())
+            .map { $0.data.map { Surah(id: $0.number,
+                                       name: $0.name,
+                                       englishName: $0.englishName,
+                                       englishNameTranslation: $0.englishNameTranslation,
+                                       numberOfAyahs: $0.numberOfAyahs) } }
+            .eraseToAnyPublisher()
+    }
+
+    func fetchAyat(forSurah number: Int) -> AnyPublisher<[Ayah], Error> {
+        let url = baseURL.appendingPathComponent("surah/\(number)/ar.uthmani")
+        return session.dataTaskPublisher(for: url)
+            .map(\.$data)
+            .decode(type: AyahListResponse.self, decoder: JSONDecoder())
+            .map { $0.data.ayahs.map { Ayah(id: $0.number,
+                                            text: $0.text,
+                                            numberInSurah: $0.numberInSurah) } }
+            .eraseToAnyPublisher()
+    }
+
+    func fetchTafsir(surah: Int, ayah: Int) -> AnyPublisher<Tafsir, Error> {
+        // Placeholder endpoint; adjust with real tafsir API
+        let url = URL(string: "https://api.quran.com/api/v4/tafsirs/by_ayah/\(ayah)?tafsir_id=169")!
+        return session.dataTaskPublisher(for: url)
+            .map(\.$data)
+            .decode(type: TafsirResponse.self, decoder: JSONDecoder())
+            .tryMap { resp in
+                guard let first = resp.tafsirs.first else {
+                    throw URLError(.badServerResponse)
+                }
+                return Tafsir(id: first.id, text: first.text, source: first.resourceName)
+            }
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Response Models
+private struct SurahListResponse: Codable {
+    struct SurahData: Codable {
+        let number: Int
+        let name: String
+        let englishName: String
+        let englishNameTranslation: String?
+        let numberOfAyahs: Int
+    }
+    let data: [SurahData]
+}
+
+private struct AyahListResponse: Codable {
+    struct AyahData: Codable {
+        let number: Int
+        let text: String
+        let numberInSurah: Int
+    }
+    struct AyahContainer: Codable {
+        let ayahs: [AyahData]
+    }
+    let data: AyahContainer
+}
+
+private struct TafsirResponse: Codable {
+    struct TafsirData: Codable {
+        let id: Int
+        let text: String
+        let resourceName: String
+    }
+    let tafsirs: [TafsirData]
+}

--- a/Salatuk Pro/QuranModule/ViewModels/SurahDetailViewModel.swift
+++ b/Salatuk Pro/QuranModule/ViewModels/SurahDetailViewModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Combine
+
+class SurahDetailViewModel: ObservableObject {
+    @Published var ayat: [Ayah] = []
+    @Published var isLoading = false
+    private var cancellables = Set<AnyCancellable>()
+    private let service: QuranAPIProtocol
+    let surah: Surah
+
+    init(surah: Surah, service: QuranAPIProtocol = QuranAPIService.shared) {
+        self.surah = surah
+        self.service = service
+    }
+
+    func loadAyat() {
+        isLoading = true
+        service.fetchAyat(forSurah: surah.id)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                self?.isLoading = false
+                if case let .failure(error) = completion {
+                    print("Failed to fetch ayat", error)
+                }
+            }, receiveValue: { [weak self] ayat in
+                self?.ayat = ayat
+            })
+            .store(in: &cancellables)
+    }
+}

--- a/Salatuk Pro/QuranModule/ViewModels/SurahListViewModel.swift
+++ b/Salatuk Pro/QuranModule/ViewModels/SurahListViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Combine
+
+class SurahListViewModel: ObservableObject {
+    @Published var surahs: [Surah] = []
+    @Published var isLoading = false
+    private var cancellables = Set<AnyCancellable>()
+    private let service: QuranAPIProtocol
+
+    init(service: QuranAPIProtocol = QuranAPIService.shared) {
+        self.service = service
+    }
+
+    func loadSurahs() {
+        isLoading = true
+        service.fetchSurahs()
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                self?.isLoading = false
+                if case let .failure(error) = completion {
+                    print("Failed to fetch surahs", error)
+                }
+            }, receiveValue: { [weak self] surahs in
+                self?.surahs = surahs
+            })
+            .store(in: &cancellables)
+    }
+}

--- a/Salatuk Pro/QuranModule/ViewModels/TafsirViewModel.swift
+++ b/Salatuk Pro/QuranModule/ViewModels/TafsirViewModel.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Combine
+
+class TafsirViewModel: ObservableObject {
+    @Published var tafsir: Tafsir?
+    @Published var isLoading = false
+    private var cancellables = Set<AnyCancellable>()
+    private let service: QuranAPIProtocol
+    let surah: Int
+    let ayah: Int
+
+    init(surah: Int, ayah: Int, service: QuranAPIProtocol = QuranAPIService.shared) {
+        self.surah = surah
+        self.ayah = ayah
+        self.service = service
+    }
+
+    func loadTafsir() {
+        isLoading = true
+        service.fetchTafsir(surah: surah, ayah: ayah)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                self?.isLoading = false
+                if case let .failure(error) = completion {
+                    print("Failed to fetch tafsir", error)
+                }
+            }, receiveValue: { [weak self] tafsir in
+                self?.tafsir = tafsir
+            })
+            .store(in: &cancellables)
+    }
+}

--- a/Salatuk Pro/QuranModule/Views/QuranHomeView.swift
+++ b/Salatuk Pro/QuranModule/Views/QuranHomeView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct QuranHomeView: View {
+    var body: some View {
+        SurahListView()
+    }
+}
+
+struct QuranHomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        QuranHomeView()
+    }
+}

--- a/Salatuk Pro/QuranModule/Views/SurahDetailView.swift
+++ b/Salatuk Pro/QuranModule/Views/SurahDetailView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// Detail view showing ayat of a surah using app styling
+
+struct SurahDetailView: View {
+    @StateObject private var viewModel: SurahDetailViewModel
+
+    init(surah: Surah) {
+        _viewModel = StateObject(wrappedValue: SurahDetailViewModel(surah: surah))
+    }
+
+    var body: some View {
+        ZStack {
+            quranBackgroundGradient.ignoresSafeArea()
+
+            List(viewModel.ayat) { ayah in
+                NavigationLink(destination: TafsirView(surah: viewModel.surah.id, ayah: ayah.numberInSurah)) {
+                    VStack(alignment: .trailing) {
+                        Text(ayah.text)
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                }
+                .listRowBackground(Color.clear)
+            }
+            .listStyle(.plain)
+        }
+        .navigationTitle(viewModel.surah.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { viewModel.loadAyat() }
+    }
+}
+
+struct SurahDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            SurahDetailView(surah: Surah(id: 1, name: "الفاتحة", englishName: "Al-Fatihah", englishNameTranslation: nil, numberOfAyahs: 7))
+        }
+    }
+}

--- a/Salatuk Pro/QuranModule/Views/SurahListView.swift
+++ b/Salatuk Pro/QuranModule/Views/SurahListView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// List of all surahs with styling similar to the rest of the app
+
+struct SurahListView: View {
+    @StateObject private var viewModel = SurahListViewModel()
+
+    var body: some View {
+        ZStack {
+            quranBackgroundGradient.ignoresSafeArea()
+
+            List(viewModel.surahs) { surah in
+                NavigationLink(destination: SurahDetailView(surah: surah)) {
+                    HStack {
+                        Text("\(surah.id).")
+                            .foregroundColor(.white)
+                        Text(surah.name)
+                            .foregroundColor(.white)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+                .listRowBackground(Color.clear)
+            }
+            .listStyle(.plain)
+        }
+        .navigationTitle(LocalizedStringKey("quran.title"))
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { viewModel.loadSurahs() }
+    }
+}
+
+struct SurahListView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView { SurahListView() }
+    }
+}

--- a/Salatuk Pro/QuranModule/Views/TafsirView.swift
+++ b/Salatuk Pro/QuranModule/Views/TafsirView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// Shows tafsir for a single ayah with app styling
+
+struct TafsirView: View {
+    @StateObject private var viewModel: TafsirViewModel
+
+    init(surah: Int, ayah: Int) {
+        _viewModel = StateObject(wrappedValue: TafsirViewModel(surah: surah, ayah: ayah))
+    }
+
+    var body: some View {
+        ZStack {
+            quranBackgroundGradient.ignoresSafeArea()
+
+            ScrollView {
+                if let tafsir = viewModel.tafsir {
+                    Text(tafsir.text)
+                        .foregroundColor(.white)
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                } else if viewModel.isLoading {
+                    ProgressView()
+                } else {
+                    Text(LocalizedStringKey("no.tafsir"))
+                        .foregroundColor(.white)
+                }
+            }
+        }
+        .navigationTitle(LocalizedStringKey("tafsir.title"))
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { viewModel.loadTafsir() }
+    }
+}
+
+struct TafsirView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView { TafsirView(surah: 1, ayah: 1) }
+    }
+}

--- a/Salatuk Pro/Resources/ar.lproj/QuranModule.strings
+++ b/Salatuk Pro/Resources/ar.lproj/QuranModule.strings
@@ -1,0 +1,3 @@
+"quran.title" = "القرآن";
+"tafsir.title" = "تفسير";
+"no.tafsir" = "لا يوجد تفسير";

--- a/Salatuk Pro/Resources/en.lproj/QuranModule.strings
+++ b/Salatuk Pro/Resources/en.lproj/QuranModule.strings
@@ -1,0 +1,3 @@
+"quran.title" = "Qur'an";
+"tafsir.title" = "Tafsir";
+"no.tafsir" = "No Tafsir";

--- a/Salatuk ProTests/QuranAPIServiceTests.swift
+++ b/Salatuk ProTests/QuranAPIServiceTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Salatuk_Pro
+
+final class QuranAPIServiceTests: XCTestCase {
+    func testFetchSurahs() {
+        // TODO: Implement network mock and verify parsing
+    }
+
+    func testFetchAyat() {
+        // TODO: Implement network mock and verify parsing
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold QuranModule with models, view models, views and services
- add Quran API service fetching surahs and ayat
- integrate Quran module entry in ContentView
- add localization strings for Quran module
- add unit test stubs for Quran API service
- style Quran views to match rest of app
- integrate QuranModule files in project

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6868064bee3c83269e28a21fbe35bf5b